### PR TITLE
Fix regex escaping for phone link conversion

### DIFF
--- a/src/components/chatbot.tsx
+++ b/src/components/chatbot.tsx
@@ -20,7 +20,9 @@ function linkifyText(text: string): string {
   let result = text
 
   // 1. Phone number linkification (specific configured phone)
-  const escapedPhone = PHONE.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')
+  // Escape any regex meta characters that might appear in the phone string
+  // so that it can be safely used in a RegExp constructor.
+  const escapedPhone = PHONE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   const phoneRegex = new RegExp(escapedPhone, 'g')
   const rawPhoneNumber = PHONE.replace(/\D/g, '')
   result = result.replace(phoneRegex, `[${PHONE}](tel:${rawPhoneNumber})`)


### PR DESCRIPTION
## Summary
- correct regex used to escape phone number in `Chatbot`

## Testing
- `pnpm test -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6884c34eb85c8325b3a0540ef643ddcc