### PR TITLE
Fix LM Studio indicator when local model is used

### DIFF
--- a/src/components/__tests__/chatbot.test.tsx
+++ b/src/components/__tests__/chatbot.test.tsx
@@ -501,7 +501,7 @@ describe('Chatbot', () => {
     // Should show LM Studio usage indicator with model name
     expect(await screen.findByText(/LM Studio response/)).toBeInTheDocument()
     expect(
-      screen.getByText(/Powered by Hugging Face \(Gemma-7B\)/),
+      screen.getByText(/Powered by local and private AI \(test-model\)/),
     ).toBeInTheDocument()
   })
 
@@ -558,7 +558,7 @@ describe('Chatbot', () => {
       await screen.findByText(/LM Studio fallback response/),
     ).toBeInTheDocument()
     expect(
-      screen.getByText(/Powered by Hugging Face \(Gemma-7B\)/),
+      screen.getByText(/Powered by local and private AI \(LM Studio\)/),
     ).toBeInTheDocument()
   })
 })

--- a/src/components/chatbot.tsx
+++ b/src/components/chatbot.tsx
@@ -155,8 +155,15 @@ export function Chatbot() {
 
       const data = await response.json()
       const answer = data.answer || 'Sorry, I could not generate an answer.'
-      const source = data.source || 'unknown'
-      const model = data.model || 'unknown'
+      const usedLmStudio =
+        data.usedLmStudio || data.source === 'lmstudio' || false
+      const lmStudioModel = usedLmStudio
+        ? data.lmStudioModel || data.model || 'LM Studio'
+        : undefined
+      const source = usedLmStudio ? 'lmstudio' : data.source || 'huggingface'
+      const model = usedLmStudio
+        ? lmStudioModel || 'LM Studio'
+        : data.model || 'unknown'
 
       // Only update state if component is still mounted
       if (isMounted.current) {
@@ -170,8 +177,8 @@ export function Chatbot() {
               answer,
               source,
               model,
-              usedLmStudio: source === 'lmstudio',
-              lmStudioModel: source === 'lmstudio' ? model : undefined,
+              usedLmStudio,
+              lmStudioModel,
             }
           }
           return updated


### PR DESCRIPTION
## Summary
- ensure chatbot respects `usedLmStudio` field from API responses
- update chatbot tests for LM Studio usage indicator

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6891d3c63d6c8325a9fb1d18012e347f