### PR TITLE
fix: allow sarif upload

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -65,6 +65,9 @@ jobs:
     name: Container Security Scan
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- allow SARIF results to upload to Security tab by granting security-events permissions to container security workflow

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689f7cc55c7c8325871e1f23870ec570