### PR TITLE
feat: improve SEO discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ The portfolio includes an intelligent chatbot that can answer questions about my
 
 The chatbot uses advanced prompt engineering and context extraction to provide accurate, helpful responses about my professional background while maintaining a friendly, conversational tone.
 
+### 📈 SEO Enhancements
+
+- **Structured Data**: JSON-LD Person schema helps search engines understand the site's owner.
+- **Sitemap**: Auto-generated sitemap exposes key pages for indexing.
+- **Robots Instructions**: robots.txt explicitly allows crawling and references the sitemap.
+
 ## CI/CD & Security
 
 This project includes comprehensive automated testing and security scanning through GitHub Actions:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://michaelfried.dev/sitemap.xml

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import Nav from '@/components/nav'
 import { ThemeProvider } from '@/components/theme-provider'
 import Link from 'next/link'
 import { Chatbot } from '@/components/chatbot'
+import Script from 'next/script'
 
 const archivo = Archivo({ subsets: ['latin'] })
 
@@ -97,9 +98,27 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: 'Michael Fried',
+    url: 'https://michaelfried.dev',
+    sameAs: [
+      'mailto:EMAIL@MICHAELFRIED.INFO',
+      'https://www.linkedin.com/in/michael-fried/',
+      'https://github.com/michaelfried-dev',
+    ],
+    jobTitle: 'Software Engineer',
+  }
   return (
     <html suppressHydrationWarning lang="en">
       <body className={archivo.className}>
+        <Script
+          id="person-schema"
+          type="application/ld+json"
+          strategy="beforeInteractive"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
         <ThemeProvider attribute="class" disableTransitionOnChange>
           <div className="outline-border rounded-base w600:grid-cols-[70px_auto] w500:grid-cols-1 portrait:w1000:max-h-[800px] mdHeight:w-[100dvw] mdHeight:max-w-[100dvw] grid h-[800px] max-h-[100dvh] w-[1000px] max-w-[1000px] grid-cols-[100px_auto] shadow-[10px_10px_0_0_#000] outline-4 portrait:h-[100dvh]">
             <header>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,24 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = 'https://michaelfried.dev'
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/experience`,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/education`,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/certifications`,
+      lastModified: new Date(),
+    },
+  ]
+}


### PR DESCRIPTION
## Summary
- embed JSON-LD Person schema in layout for better search engine association
- add sitemap generation and expose key pages for indexing
- include robots.txt that allows crawling and references the sitemap
- document SEO enhancements in README

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0a87a550c8325a395771a28b09794