### PR TITLE
feat: clarify chatbot identity

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -76,7 +76,7 @@ async function tryLmStudioFallback(
   console.log('[DEBUG] Attempting LM Studio fallback:', lmStudioUrl)
 
   try {
-    const systemPrompt = `You are a helpful assistant that answers questions about the following resume and portfolio content. Provide direct, concise answers that include relevant emojis and colorful language to make your responses engaging and visually appealing. Use markdown formatting when appropriate to highlight important points.
+    const systemPrompt = `You are the AI chatbot built for Michael Fried's personal portfolio website and you are currently running on this site. Answer questions about the following resume and portfolio content. Provide direct, concise answers that include relevant emojis and colorful language to make your responses engaging and visually appealing. Use markdown formatting when appropriate to highlight important points.
 
 Context:\n${context}`
 
@@ -324,7 +324,7 @@ Feel free to reach out for professional networking, questions about my experienc
       const client = new InferenceClient(apiKey)
       const huggingFaceModel =
         process.env.HUGGINGFACE_MODEL || 'google/gemma-7b-it'
-      const systemPrompt = `You are a helpful assistant that answers questions about the following resume and portfolio content. Provide direct, concise answers that include relevant emojis and colorful language to make your responses engaging and visually appealing. Use markdown formatting when appropriate to highlight important points. Context:\n${context}`
+      const systemPrompt = `You are the AI chatbot built for Michael Fried's personal portfolio website and you are currently running on this site. Answer questions about the following resume and portfolio content. Provide direct, concise answers that include relevant emojis and colorful language to make your responses engaging and visually appealing. Use markdown formatting when appropriate to highlight important points. Context:\n${context}`
       console.log(`[DEBUG] Using Hugging Face model: ${huggingFaceModel}`)
       const result = await client.chatCompletion({
         model: huggingFaceModel,


### PR DESCRIPTION
## Summary
- clarify system prompt to state chatbot is running on personal portfolio site
- add tests verifying site-identifying system prompt for Hugging Face and LM Studio fallback

## Testing
- `pnpm test --no-color`


------
https://chatgpt.com/codex/tasks/task_e_68a23af20da883258ede2637164fa35c