### PR TITLE
Update site content from latest resume

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -222,7 +222,7 @@ Feel free to reach out for professional networking, questions about my experienc
       }).join('\n')
 
       // Education
-      const eduText = `Education: ${EDUCATION.degree}\n${EDUCATION.school} | ${EDUCATION.location} | ${EDUCATION.date}\n${EDUCATION.minor}\n${EDUCATION.gpa}\n`
+      const eduText = `Education: ${EDUCATION.degree}\n${EDUCATION.school} | ${EDUCATION.location} | ${EDUCATION.date}\n${EDUCATION.minor}\n`
 
       // Certifications
       let certText = CERTIFICATIONS.map(

--- a/src/app/education/__tests__/page.test.tsx
+++ b/src/app/education/__tests__/page.test.tsx
@@ -35,8 +35,7 @@ describe('EducationPage', () => {
     expect(minor).toBeInTheDocument()
   })
 
-  it('should render the GPA', () => {
-    const gpa = screen.getByText(/Cumulative GPA: 3.37/i)
-    expect(gpa).toBeInTheDocument()
+  it('should not render the GPA', () => {
+    expect(screen.queryByText(/Cumulative GPA/i)).not.toBeInTheDocument()
   })
 })

--- a/src/app/education/page.tsx
+++ b/src/app/education/page.tsx
@@ -16,7 +16,6 @@ export default function EducationPage() {
             {education.school} | {education.location} | {education.date}
           </p>
           <p>{education.minor}</p>
-          <p>{education.gpa}</p>
         </CardContent>
       </Card>
     </div>

--- a/src/app/experience/__tests__/page.test.tsx
+++ b/src/app/experience/__tests__/page.test.tsx
@@ -1,49 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import ExperiencePage from '../page'
-
-const experience = [
-  {
-    company: 'Personal Projects',
-    title: 'Personal Portfolio Website',
-  },
-  {
-    company: 'Lincoln Financial Group',
-    title: 'Software Engineer',
-    location: 'Philadelphia, PA',
-    date: 'January 2023 - November 2024',
-  },
-  {
-    company: 'SoFi',
-    title: 'Software Engineer',
-    location: 'Claymont, Delaware',
-    date: 'January 2020 - January 2023',
-  },
-  {
-    company: 'Agile Trailblazers',
-    title: 'Software Development Engineer',
-    location: 'Media, Pennsylvania',
-    date: 'February 2016 - December 2019',
-  },
-  {
-    company: 'Fiserv',
-    title: 'Software Development Engineer',
-    location: 'King of Prussia, Pennsylvania',
-    date: 'July 2013 – January 2016',
-  },
-  {
-    company: 'Lockheed Martin',
-    title: 'Software Engineer/Web Developer',
-    location: 'Cherry Hill, New Jersey',
-    date: 'April 2011 – September 2012',
-  },
-  {
-    company: 'Wharton Business School',
-    title: 'Computer Support Representative',
-    location: 'Philadelphia, Pennsylvania',
-    date: 'March 2010 – September 2010',
-  },
-]
+import { EXPERIENCE } from '@/lib/constants'
 
 describe('ExperiencePage', () => {
   beforeEach(() => {
@@ -51,7 +9,7 @@ describe('ExperiencePage', () => {
   })
 
   it('should render all company names as headings', () => {
-    experience.forEach((job) => {
+    EXPERIENCE.forEach((job) => {
       const heading = screen.getByRole('heading', {
         name: job.company,
         level: 3,
@@ -61,7 +19,7 @@ describe('ExperiencePage', () => {
   })
 
   it('should render all job titles', () => {
-    experience.forEach((job) => {
+    EXPERIENCE.forEach((job) => {
       const titles = screen.getAllByText(job.title)
       expect(titles.length).toBeGreaterThan(0)
       titles.forEach((title) => expect(title).toBeInTheDocument())
@@ -69,9 +27,9 @@ describe('ExperiencePage', () => {
   })
 
   it('should render all locations and dates when available', () => {
-    experience.forEach((job) => {
-      // Skip Personal Projects which doesn't have location and date
-      if (job.company === 'Personal Projects') return
+    EXPERIENCE.forEach((job) => {
+      // Skip entries without location/date (e.g. Personal Projects)
+      if (!('location' in job) || !('date' in job)) return
 
       const locationAndDate = screen.getByText(`${job.location} | ${job.date}`)
       expect(locationAndDate).toBeInTheDocument()
@@ -80,6 +38,6 @@ describe('ExperiencePage', () => {
 
   it('should render the correct number of job cards', () => {
     const jobCards = screen.getAllByRole('heading', { level: 3 })
-    expect(jobCards).toHaveLength(experience.length)
+    expect(jobCards).toHaveLength(EXPERIENCE.length)
   })
 })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import BuyMeACoffeeButton from '@/components/BuyMeACoffeeButton'
+import { CONTACT_INFO } from '@/lib/constants'
 
 type IconComponent = ComponentType<
   SVGProps<SVGSVGElement> & { className?: string }
@@ -15,7 +16,7 @@ export default function Home() {
   const links: { icon: IconComponent; href: string; label: string }[] = [
     {
       icon: SiGmail,
-      href: 'mailto:EMAIL@MICHAELFRIED.INFO',
+      href: `mailto:${CONTACT_INFO.email}`,
       label: 'Email',
     },
     {
@@ -76,20 +77,22 @@ export default function Home() {
           <Card className="bg-card text-foreground border-border rounded-base border-4 p-5 shadow-[8px_8px_0_0_#000]">
             <CardContent>
               <p>
-                Hi, I&apos;m <strong>Michael</strong>! As a software engineer, I
-                enjoy taking projects all the way from an initial idea to a
-                fully-realized product. I&apos;m comfortable in both Agile and
-                traditional development environments, and I have a passion for
-                building high-performance backend microservices using tools like
-                Kotlin, Java, and Spring. I also have experience with front-end
-                development for both web and iOS.
+                Hi, I&apos;m <strong>Michael</strong>! I&apos;m a software
+                engineer who loves taking projects from an initial idea all the
+                way to production. I specialize in building high-performance
+                backend microservices with Kotlin, Java, and Spring, and
+                I&apos;m equally comfortable on the front end with React,
+                Angular, and TypeScript.
               </p>
               <p className="pt-[10px]">
-                I believe that quality is key, so I always focus on creating
-                comprehensive automated tests to ensure everything runs
-                smoothly. I&apos;m a quick learner and I&apos;m always excited
-                to dive into new technologies to find the best solutions for the
-                job. Feel free to connect with me!
+                I&apos;m a strong advocate for AI-assisted development — I use
+                tools like GitHub Copilot and Claude Code daily for everything
+                from rapid prototyping and test generation to agentic,
+                multi-step feature builds and code review. Quality is always a
+                priority, so I pair that speed with comprehensive automated
+                testing at every level. I&apos;m a quick learner who&apos;s
+                always excited to dive into new technologies to find the best
+                solution for the job. Feel free to connect with me!
               </p>
               <p className="pt-[20px]">
                 Check out the repository for this site{' '}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,7 +18,6 @@ export const EDUCATION = {
   degree: 'Bachelor of Science (BS), Software Engineering',
   minor: 'Minor: Computer Science',
   date: 'August 2008 - July 2013',
-  gpa: 'Cumulative GPA: 3.37',
 } as const
 
 export const CERTIFICATIONS = [

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,7 +9,7 @@ export const CONTACT_INFO = {
 export const PERSONAL_INFO = {
   name: 'Michael Fried',
   title: 'Software Engineer',
-  about: `Hi, I'm Michael! As a software engineer, I enjoy taking projects all the way from an initial idea to a fully-realized product. I'm comfortable in both Agile and traditional development environments, and I have a passion for building high-performance backend microservices using tools like Kotlin, Java, and Spring. I also have experience with front-end development for both web and iOS. I believe that quality is key, so I always focus on creating comprehensive automated tests to ensure everything runs smoothly. I'm a quick learner and I'm always excited to dive into new technologies to find the best solutions for the job. Feel free to connect with me!`,
+  about: `Hi, I'm Michael! I'm a software engineer who loves taking projects from an initial idea all the way to production. I specialize in building high-performance backend microservices with Kotlin, Java, and Spring, and I'm equally comfortable on the front end with React, Angular, and TypeScript. I'm a strong advocate for AI-assisted development — I use tools like GitHub Copilot and Claude Code daily for everything from rapid prototyping and test generation to agentic, multi-step feature builds and code review. Quality is always a priority, so I pair that speed with comprehensive automated testing at every level. I'm a quick learner who's always excited to dive into new technologies to find the best solution for the job. Feel free to connect with me!`,
 } as const
 
 export const EDUCATION = {
@@ -34,11 +34,26 @@ export const CERTIFICATIONS = [
 
 export const EXPERIENCE = [
   {
+    company: 'JPMorgan Chase',
+    location: 'Wilmington, DE',
+    title: 'Software Engineer III',
+    date: 'August 2025 – Present',
+    description: [
+      'Develop and maintain third-party integration services that interface with the three major credit bureaus (Equifax, Experian, TransUnion), ensuring reliable, high-volume data exchange for consumer lending workflows.',
+      'Design and implement a cross-region resiliency framework that intelligently routes and retries credit data requests across multiple bureaus and AWS regions, ensuring complete data retrieval even when individual bureau calls or regions fail.',
+      'Build and enhance backend microservices using Java and Spring Boot, backed by Postgres and Amazon Aurora datastores.',
+      'Provision and manage cloud infrastructure with Terraform and deploy containerized services to AWS ECS via Spinnaker continuous-delivery pipelines, utilizing S3 for artifact storage and configuration management.',
+      'Write and maintain API integration tests using Karate and validate endpoints with Bruno for rapid manual testing and debugging.',
+      'Leverage GitHub Copilot, Claude Code, and Jules to accelerate development — from AI-assisted coding and automated test generation to agentic, multi-step feature implementation and code-review workflows.',
+      'Monitor application health and troubleshoot production issues using Splunk dashboards and alerts.',
+    ],
+  },
+  {
     company: 'Personal Projects',
     title: 'Personal Portfolio Website',
     description: [
       'Developed this portfolio website using Next.js 15, React 19, TypeScript, and Tailwind CSS, featuring a responsive design with light/dark mode and smooth animations.',
-      'Utilized AI copilot Windsurf to enhance development productivity and implement best practices throughout the codebase.',
+      'Utilized AI development tools including Windsurf, GitHub Copilot, and Claude Code to enhance development productivity, generate tests, and implement best practices throughout the codebase.',
       'Implemented an AI-powered chatbot with a dual-API architecture that seamlessly integrates with both Hugging Face AI APIs and local LM Studio models for privacy-focused, resilient interactions.',
       'Created a fallback system that automatically switches between cloud and local AI providers based on availability, ensuring 100% uptime of the interactive assistant feature.',
       'Built a containerized deployment pipeline using Docker and GitHub Actions for automated testing, dependency management, and continuous deployment to Cloudflare Pages.',


### PR DESCRIPTION
## Summary
- **New job**: JPMorgan Chase — Software Engineer III (Aug 2025–Present) added to the top of the experience section
- **Updated summary**: About text now reflects current resume — emphasizes AI-assisted development (GitHub Copilot, Claude Code), React/Angular front-end work, and the shift to a quality-first mindset
- **Portfolio blurb**: Updated to credit Windsurf, GitHub Copilot, and Claude Code (was only Windsurf before)
- **Bug fix**: Email `href` in page.tsx was hardcoded as `EMAIL@MICHAELFRIED.INFO` (uppercase) — now uses `CONTACT_INFO.email` to stay in sync with constants
- **Test improvement**: Experience page test now imports directly from `EXPERIENCE` constant instead of a hardcoded duplicate array — will never fall out of sync again

## Test plan
- [ ] Home page about text matches resume summary
- [ ] Experience page shows JPMorgan Chase at the top with correct title, location, and bullets
- [ ] Email button on home page links to correct lowercase address
- [ ] All 115 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)