### PR TITLE
Rebrand display name to Mike; switch canonical domain to mikefried.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mike's Professional Portfolio
 
-🤖 **Built with AI & Windsurf** - This portfolio was developed using AI-powered development tools and the Windsurf IDE, showcasing modern AI-assisted software development practices.
+🤖 **Built with AI** - This portfolio was developed using AI-powered development tools, showcasing modern AI-assisted software development practices.
 
 This repository contains the source code for my personal portfolio website, designed to showcase my skills, professional experience, and project work. The site features a modern, clean, neobrutalist aesthetic and is fully responsive across all devices.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Michael's Professional Portfolio
+# Mike's Professional Portfolio
 
 🤖 **Built with AI & Windsurf** - This portfolio was developed using AI-powered development tools and the Windsurf IDE, showcasing modern AI-assisted software development practices.
 
@@ -26,7 +26,7 @@ The portfolio includes an intelligent chatbot that can answer questions about my
 - **Local Fallback**: Seamless fallback to local LM Studio API when cloud quota is exceeded
 - **Safari Compatible**: Optimized for all browsers including Safari with proper caching headers
 - **Responsive Design**: Works seamlessly on both desktop and mobile devices
-- **Natural Conversations**: Ask questions like "Where did Michael work in 2023?" or "What are his technical skills?"
+- **Natural Conversations**: Ask questions like "Where did Mike work in 2023?" or "What are his technical skills?"
 
 The chatbot uses advanced prompt engineering and context extraction to provide accurate, helpful responses about my professional background while maintaining a friendly, conversational tone.
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Michael Fried - AI-Powered Portfolio",
-  "short_name": "Michael Fried",
+  "name": "Mike Fried - AI-Powered Portfolio",
+  "short_name": "Mike Fried",
   "description": "Professional portfolio showcasing software engineering expertise with AI-powered chatbot assistance",
   "start_url": "/",
   "display": "standalone",

--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -28,7 +28,7 @@ describe('Layout Metadata', () => {
     expect(metadata.description).toBeDefined()
     expect(metadata.keywords).toBeDefined()
     expect(metadata.creator).toBeDefined()
-    expect(metadata.creator).toContain('Michael Fried')
+    expect(metadata.creator).toContain('Mike Fried')
   })
 })
 
@@ -56,11 +56,11 @@ describe('Layout Metadata', () => {
 
     // Type assertion for title which can be string | TitleTemplate
     const title = metadata.title as { default: string; template: string }
-    expect(title.default).toBe('Michael Fried - Portfolio')
-    expect(title.template).toBe('%s | Michael Fried')
+    expect(title.default).toBe('Mike Fried - Portfolio')
+    expect(title.template).toBe('%s | Mike Fried')
 
     expect(metadata.description).toBe(
-      "Michael Fried's professional portfolio showcasing software engineering expertise, AI-powered chatbot assistance, and innovative projects built with modern web technologies.",
+      "Mike Fried's professional portfolio showcasing software engineering expertise, AI-powered chatbot assistance, and innovative projects built with modern web technologies.",
     )
   })
 

--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -5,9 +5,9 @@ import Page from '../page'
 describe('Page', () => {
   it('renders the main heading', () => {
     render(<Page />)
-    // The text is now split across multiple elements with "Michael" in a <strong> tag
+    // The text is now split across multiple elements with "Mike" in a <strong> tag
     const heading = screen.getByText(/Hi, I'm/i)
-    const name = screen.getByText('Michael')
+    const name = screen.getByText('Mike')
     expect(heading).toBeInTheDocument()
     expect(name).toBeInTheDocument()
     expect(name.tagName).toBe('STRONG')
@@ -18,7 +18,7 @@ describe('Page', () => {
 
     // Check for the GitHub contact link
     const githubContactLink = screen.getByRole('link', {
-      name: /Contact Michael Fried via GitHub/i,
+      name: /Contact Mike Fried via GitHub/i,
     })
     expect(githubContactLink).toBeInTheDocument()
     expect(githubContactLink).toHaveAttribute(
@@ -39,10 +39,10 @@ describe('Page', () => {
 
     // Check for other contact links to ensure they are still present
     expect(
-      screen.getByRole('link', { name: /Contact Michael Fried via Email/i }),
+      screen.getByRole('link', { name: /Contact Mike Fried via Email/i }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('link', { name: /Contact Michael Fried via LinkedIn/i }),
+      screen.getByRole('link', { name: /Contact Mike Fried via LinkedIn/i }),
     ).toBeInTheDocument()
   })
 })

--- a/src/app/api/chat/__tests__/route.test.ts
+++ b/src/app/api/chat/__tests__/route.test.ts
@@ -213,7 +213,7 @@ describe('POST /api/chat', () => {
       (msg: any) => msg.role === 'system',
     )
     expect(systemMessage.content).toContain(
-      "You are the AI chatbot built for Michael Fried's personal portfolio website and you are currently running on this site",
+      "You are the AI chatbot built for Mike Fried's personal portfolio website and you are currently running on this site",
     )
     jest.dontMock('@huggingface/inference')
   })
@@ -455,7 +455,7 @@ describe('POST /api/chat', () => {
         (m: any) => m.role === 'system',
       )
       expect(systemMessage.content).toContain(
-        "You are the AI chatbot built for Michael Fried's personal portfolio website and you are currently running on this site",
+        "You are the AI chatbot built for Mike Fried's personal portfolio website and you are currently running on this site",
       )
     })
 

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -154,7 +154,7 @@ async function tryLmStudioFallback(
   }
 
   try {
-    const systemPrompt = `You are the AI chatbot built for Michael Fried's personal portfolio website and you are currently running on this site. Answer questions about the following resume and portfolio content. Provide direct, concise answers that include relevant emojis and colorful language to make your responses engaging and visually appealing. Use markdown formatting when appropriate to highlight important points.
+    const systemPrompt = `You are the AI chatbot built for Mike Fried's personal portfolio website and you are currently running on this site. Answer questions about the following resume and portfolio content. Provide direct, concise answers that include relevant emojis and colorful language to make your responses engaging and visually appealing. Use markdown formatting when appropriate to highlight important points.
 
 Context:\n${context}`
 
@@ -515,7 +515,7 @@ Feel free to reach out for professional networking, questions about my experienc
       const client = new InferenceClient(apiKey)
       const huggingFaceModel =
         process.env.HUGGINGFACE_MODEL || 'google/gemma-7b-it'
-      const systemPrompt = `You are the AI chatbot built for Michael Fried's personal portfolio website and you are currently running on this site. Answer questions about the following resume and portfolio content. Provide direct, concise answers that include relevant emojis and colorful language to make your responses engaging and visually appealing. Use markdown formatting when appropriate to highlight important points. Context:\n${context}`
+      const systemPrompt = `You are the AI chatbot built for Mike Fried's personal portfolio website and you are currently running on this site. Answer questions about the following resume and portfolio content. Provide direct, concise answers that include relevant emojis and colorful language to make your responses engaging and visually appealing. Use markdown formatting when appropriate to highlight important points. Context:\n${context}`
       const result = await client.chatCompletion({
         model: huggingFaceModel,
         messages: [

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,11 +12,11 @@ const archivo = Archivo({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
   title: {
-    default: 'Michael Fried - Portfolio',
-    template: '%s | Michael Fried',
+    default: 'Mike Fried - Portfolio',
+    template: '%s | Mike Fried',
   },
   description:
-    "Michael Fried's professional portfolio showcasing software engineering expertise, AI-powered chatbot assistance, and innovative projects built with modern web technologies.",
+    "Mike Fried's professional portfolio showcasing software engineering expertise, AI-powered chatbot assistance, and innovative projects built with modern web technologies.",
   viewport: {
     width: 'device-width',
     initialScale: 1,
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
     'format-detection': 'telephone=no,date=no,address=no,email=no,url=no',
   },
   keywords: [
-    'Michael Fried',
+    'Mike Fried',
     'Software Engineer',
     'AI Portfolio',
     'Web Development',
@@ -37,30 +37,30 @@ export const metadata: Metadata = {
     'Next.js',
     'TypeScript',
   ],
-  authors: [{ name: 'Michael Fried' }],
-  creator: 'Michael Fried',
-  publisher: 'Michael Fried',
+  authors: [{ name: 'Mike Fried' }],
+  creator: 'Mike Fried',
+  publisher: 'Mike Fried',
   formatDetection: {
     email: false,
     address: false,
     telephone: false,
   },
-  metadataBase: new URL('https://michaelfried.info'),
+  metadataBase: new URL('https://mikefried.dev'),
   alternates: {
     canonical: '/',
   },
   openGraph: {
-    title: 'Michael Fried - Portfolio',
+    title: 'Mike Fried - Portfolio',
     description:
       'Professional portfolio showcasing software engineering expertise with AI-powered chatbot assistance.',
-    url: 'https://michaelfried.info',
-    siteName: 'Michael Fried Portfolio',
+    url: 'https://mikefried.dev',
+    siteName: 'Mike Fried Portfolio',
     images: [
       {
         url: '/profile.jpg',
         width: 1200,
         height: 630,
-        alt: 'Michael Fried - Software Engineer',
+        alt: 'Mike Fried - Software Engineer',
       },
     ],
     locale: 'en_US',
@@ -68,7 +68,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Michael Fried - Portfolio',
+    title: 'Mike Fried - Portfolio',
     description:
       'Professional portfolio showcasing software engineering expertise with AI-powered chatbot assistance.',
     images: ['/profile.jpg'],
@@ -100,8 +100,8 @@ export default function RootLayout({
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'Person',
-    name: 'Michael Fried',
-    url: 'https://michaelfried.info',
+    name: 'Mike Fried',
+    url: 'https://mikefried.dev',
     sameAs: [
       'mailto:EMAIL@MICHAELFRIED.INFO',
       'https://www.linkedin.com/in/michael-fried/',
@@ -135,7 +135,7 @@ export default function RootLayout({
               >
                 <h1 className="smallHeight:text-[30px] smallHeight:tracking-[2px] w600:text-[30px] w600:tracking-[2px] -rotate-90 text-[40px] font-bold tracking-[4px] whitespace-nowrap">
                   <span className="text-main-foreground inline-block">
-                    MICHAEL FRIED
+                    MIKE FRIED
                   </span>
                 </h1>
               </Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,7 +40,7 @@ export default function Home() {
             <Avatar className="rounded-base border-border size-[200px] border-4 shadow-[8px_8px_0_0_#000]">
               <AvatarImage
                 src="/profile.jpg"
-                alt="Michael Fried - Software Engineer profile photo"
+                alt="Mike Fried - Software Engineer profile photo"
               />
               <AvatarFallback className="text-6xl">MF</AvatarFallback>
             </Avatar>
@@ -54,7 +54,7 @@ export default function Home() {
                 >
                   <Link
                     href={href}
-                    aria-label={`Contact Michael Fried via ${label}`}
+                    aria-label={`Contact Mike Fried via ${label}`}
                     {...(href.startsWith('http')
                       ? { target: '_blank', rel: 'noopener noreferrer' }
                       : {})}
@@ -77,12 +77,12 @@ export default function Home() {
           <Card className="bg-card text-foreground border-border rounded-base border-4 p-5 shadow-[8px_8px_0_0_#000]">
             <CardContent>
               <p>
-                Hi, I&apos;m <strong>Michael</strong>! I&apos;m a software
-                engineer who loves taking projects from an initial idea all the
-                way to production. I specialize in building high-performance
-                backend microservices with Kotlin, Java, and Spring, and
-                I&apos;m equally comfortable on the front end with React,
-                Angular, and TypeScript.
+                Hi, I&apos;m <strong>Mike</strong>! I&apos;m a software engineer
+                who loves taking projects from an initial idea all the way to
+                production. I specialize in building high-performance backend
+                microservices with Kotlin, Java, and Spring, and I&apos;m
+                equally comfortable on the front end with React, Angular, and
+                TypeScript.
               </p>
               <p className="pt-[10px]">
                 I&apos;m a strong advocate for AI-assisted development — I use

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from 'next'
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://michaelfried.info'
+  const baseUrl = 'https://mikefried.dev'
 
   return [
     {

--- a/src/components/chatbot.tsx
+++ b/src/components/chatbot.tsx
@@ -416,7 +416,7 @@ export function Chatbot() {
                     className="flex-1"
                     placeholder={
                       CHATBOT_ENABLED
-                        ? 'e.g. Where did Michael Fried work in 2023?'
+                        ? 'e.g. Where did Mike Fried work in 2023?'
                         : 'AI Assistant is currently disabled'
                     }
                     disabled={isLoading || !CHATBOT_ENABLED}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -133,14 +133,7 @@ export const EXPERIENCE = [
 export const SKILLS = [
   {
     category: 'AI-Augmented Engineering',
-    items: [
-      'Claude Code',
-      'GitHub Copilot',
-      'Cursor',
-      'Jules (agentic coding, test generation, code review)',
-      'Windsurf',
-      'LM Studio',
-    ],
+    items: ['Claude Code', 'GitHub Copilot', 'LM Studio'],
   },
   {
     category: 'Programming Languages',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -7,9 +7,9 @@ export const CONTACT_INFO = {
 } as const
 
 export const PERSONAL_INFO = {
-  name: 'Michael Fried',
+  name: 'Mike Fried',
   title: 'Software Engineer',
-  about: `Hi, I'm Michael! I'm a software engineer who loves taking projects from an initial idea all the way to production. I specialize in building high-performance backend microservices with Kotlin, Java, and Spring, and I'm equally comfortable on the front end with React, Angular, and TypeScript. I believe AI is the biggest force multiplier in modern engineering — I treat tools like Claude Code, GitHub Copilot, and Cursor as core parts of my workflow, not add-ons, using them for everything from rapid prototyping and agentic feature builds to test generation and code review. Quality is always a priority, so I pair that speed with comprehensive automated testing at every level. I'm a quick learner who's always excited to dive into new technologies to find the best solution for the job. Feel free to connect with me!`,
+  about: `Hi, I'm Mike! I'm a software engineer who loves taking projects from an initial idea all the way to production. I specialize in building high-performance backend microservices with Kotlin, Java, and Spring, and I'm equally comfortable on the front end with React, Angular, and TypeScript. I believe AI is the biggest force multiplier in modern engineering — I treat tools like Claude Code, GitHub Copilot, and Cursor as core parts of my workflow, not add-ons, using them for everything from rapid prototyping and agentic feature builds to test generation and code review. Quality is always a priority, so I pair that speed with comprehensive automated testing at every level. I'm a quick learner who's always excited to dive into new technologies to find the best solution for the job. Feel free to connect with me!`,
 } as const
 
 export const EDUCATION = {


### PR DESCRIPTION
## Summary
- Flip every **display-name** reference from "Michael" / "Michael Fried" to "Mike" / "Mike Fried" across page metadata, JSON-LD, OG/Twitter tags, manifest, page copy, chatbot system prompts, the avatar corner header, and the README.
- Point the canonical site URL at `https://mikefried.dev` in `metadataBase`, `openGraph.url`, JSON-LD `url`, and the sitemap `baseUrl`. `mikefried.dev` becomes primary; the old `michaelfried.info` will be repointed as the redirected alias.
- Update test assertions to match the new strings (146/146 still pass).

## Intentionally left alone
- `email@michaelfried.info` — mailbox not yet provisioned at the new domain.
- `github.com/michaelfried-dev` repo + profile URLs.
- LinkedIn slug `linkedin.com/in/michael-fried/`.
- `coff.ee/michaelfried` Buy-Me-a-Coffee handle.
- `public/robots.txt` already references `mikefried.dev` — no change needed.

## Test plan
- [x] `pnpm test` — 146/146 pass across 20 suites
- [x] `pnpm type-check` — clean
- [x] `pnpm format` — applied
- [ ] CI green (CI will verify on the PR)
- [ ] Smoke-check the Cloudflare Pages preview deployment: title, OG card, sitemap entries, JSON-LD all reflect "Mike Fried" and `mikefried.dev`
- [ ] After merge + DNS flip, verify `https://mikefried.dev` serves canonical and `https://michaelfried.info` redirects to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)