### PR TITLE
Fix ThemeSwitcher overflowing nav corner at desktop widths

### DIFF
--- a/src/components/__tests__/nav.test.tsx
+++ b/src/components/__tests__/nav.test.tsx
@@ -90,6 +90,35 @@ describe('Nav component', () => {
     ).toBeGreaterThanOrEqual(1)
   })
 
+  it('desktop grid wraps ThemeSwitcher in a styled cell with border-l-4 and bg-main', () => {
+    mockedUsePathname.mockReturnValue('/')
+    render(<Nav />)
+
+    // The desktop grid is the second major section (after the mobile bar).
+    // Its ThemeSwitcher is the second one in the DOM.
+    const switchers = screen.getAllByTestId('theme-switcher')
+    const desktopSwitcher = switchers[1]
+
+    // The wrapper cell must own the border and background, not the button itself.
+    const cell = desktopSwitcher.parentElement!
+    expect(cell).toHaveClass('border-l-4')
+    expect(cell).toHaveClass('bg-main')
+  })
+
+  it('mobile bar wraps ThemeSwitcher in a styled cell with border-l-2 and bg-main', () => {
+    mockedUsePathname.mockReturnValue('/')
+    render(<Nav />)
+
+    // The mobile bar's ThemeSwitcher is the first one in the DOM.
+    const switchers = screen.getAllByTestId('theme-switcher')
+    const mobileSwitcher = switchers[0]
+
+    // The wrapper cell must own the border and background.
+    const cell = mobileSwitcher.parentElement!
+    expect(cell).toHaveClass('border-l-2')
+    expect(cell).toHaveClass('bg-main')
+  })
+
   // ── Hamburger button ────────────────────────────────────────────────────────
 
   it('renders the hamburger toggle button', () => {

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -54,7 +54,9 @@ export default function Nav() {
         </span>
 
         <div className="flex h-full items-center">
-          <ThemeSwitcher />
+          <div className="border-border bg-main flex h-full w-[50px] items-center justify-center border-l-2">
+            <ThemeSwitcher />
+          </div>
           <button
             ref={toggleRef}
             aria-label="Toggle menu"

--- a/src/components/theme-switcher.tsx
+++ b/src/components/theme-switcher.tsx
@@ -10,11 +10,11 @@ export function ThemeSwitcher() {
 
   return (
     <button
-      className="w500:h-9 border-l-border w500:w-9 rounded-tr-base bg-main flex w-[50px] items-center justify-center border-l-2 p-0 portrait:rounded-none"
+      className="flex h-full w-full items-center justify-center p-0"
       onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
     >
-      <Sun className="w500:size-4 stroke-main-foreground hidden size-6 dark:inline" />
-      <Moon className="w500:size-4 stroke-main-foreground inline size-6 dark:hidden" />
+      <Sun className="stroke-main-foreground hidden size-6 dark:inline" />
+      <Moon className="stroke-main-foreground inline size-6 dark:hidden" />
       <span className="sr-only">Toggle theme</span>
     </button>
   )


### PR DESCRIPTION
## Bug
At desktop widths the dark/light-mode toggle button rendered broken: the moon/sun icon appeared to float **above and to the right of the nav bar**, partially outside the window's rounded `rounded-tr-base` corner, and the last grid cell looked like it was missing its `bg-main` background.

## Root cause
Two issues compounding in `theme-switcher.tsx`:
1. **Width overflow.** The button declared its own `w-[50px]` AND `border-l-2` while sitting in a desktop grid column that's exactly 50px wide. The border added on top of the declared width — overflowing the column by 2px and clipping against the rounded corner.
2. **Zero height at desktop.** `h-9` was gated behind the `w500:` (≤500px) breakpoint, so at anything wider the button had no height and collapsed to bare-icon height. The icon ended up vertically centered in a zero-height box and visually "escaped" the nav frame.

## Fix
- **`src/components/theme-switcher.tsx`** — strip `bg-main`, `rounded-tr-base`, `border-l-2`, `w-[50px]`, and the `w500:h-9 w500:w-9` overrides. Replace with `h-full w-full` so the button fills whatever cell wraps it. The component becomes content-only; layout responsibility moves to the cell.
- **`src/components/nav.tsx`** — wrap the mobile bar's bare `<ThemeSwitcher />` in a `div` with `border-l-2 bg-main h-full w-[50px]`, mirroring the desktop cell that was already correct.

## Tests
- Added 2 assertions to `src/components/__tests__/nav.test.tsx`:
  - Desktop grid's wrapper cell carries `border-l-4` and `bg-main`.
  - Mobile bar's wrapper cell carries `border-l-2` and `bg-main`.

## Test plan
- [x] `pnpm test` — 148/148 pass (146 baseline + 2 new regression tests)
- [x] `pnpm type-check` — clean
- [x] `pnpm format` — no changes needed
- [ ] **Browser smoke-test on the Cloudflare preview** at:
  - ~1000px width (the original screenshot's viewport) — confirm the toggle now sits inside the nav's rounded corner with proper `bg-main` background.
  - Exactly 700px (the `w700` breakpoint boundary) — confirm the mobile↔desktop transition is clean with no double-border on the theme cell.
  - ≤500px — the icon stays `size-6` at all widths now (the old `w500:size-4` shrink was removed). Flag if it looks too large on phones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)