### PR TITLE
Add .prettierignore so Dependabot lockfile bumps stop failing format:check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,14 @@
+# Auto-generated lockfiles
+pnpm-lock.yaml
+
+# Build outputs
+.next/
+out/
+coverage/
+
+# Dependencies
+node_modules/
+
+# Minified assets
+*.min.js
+*.min.css


### PR DESCRIPTION
## Why
Every open Dependabot PR fails the **Code Quality Checks** workflow with:

```
[warn] pnpm-lock.yaml
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
```

`prettier --check .` was scanning the lockfile (and any other build artifacts). Lockfiles are autogenerated and not meant to be prettier-formatted, so this fails on every dependency bump regardless of whether the underlying upgrade is sound.

## Fix
Add `.prettierignore` listing the file/dir patterns prettier should skip:
- `pnpm-lock.yaml` (the immediate cause)
- `.next/`, `out/`, `coverage/`, `node_modules/` (build/dep artifacts)
- `*.min.js`, `*.min.css` (minified assets)

## Verification
- [x] `pnpm format:check` — "All matched files use Prettier code style!"
- [x] `pnpm test` — 146/146 pass
- [ ] Once merged, rebase the open Dependabot PRs and their Code Quality check should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)